### PR TITLE
Build Dockerimage from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,2 @@
 .tox/**/*
-src/**/*
-CHANGES.txt
-LICENSE
-README.rst
-setup.py
 tox.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # docker build --tag eu.gcr.io/zeitonline-210413/bugsnag-exporter:PACKAGEVERSION-DOCKERVERSION .
 FROM python:3.9.5-slim
 WORKDIR /app
+RUN pip install --upgrade pip
 COPY requirements.txt ./
 RUN pip install --no-deps -r requirements.txt
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # docker build --tag eu.gcr.io/zeitonline-210413/bugsnag-exporter:PACKAGEVERSION-DOCKERVERSION .
 FROM python:3.9.5-slim
 WORKDIR /app
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "${VIRTUAL_ENV}"
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 RUN pip install --upgrade pip
 COPY requirements.txt ./
 RUN pip install --no-deps -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # docker build --tag eu.gcr.io/zeitonline-210413/bugsnag-exporter:PACKAGEVERSION-DOCKERVERSION .
 FROM python:3.9.5-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY requirements.txt ./
 RUN pip install --no-deps -r requirements.txt
+COPY ./ ./
+RUN pip install --use-feature=in-tree-build --no-deps .
 ENTRYPOINT ["bugsnag_exporter"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-bugsnag_exporter==1.1.1
-
 prometheus-client==0.11.0
 
 requests==2.25.1


### PR DESCRIPTION
Usually you try getting source into the container image through the local filesystem, this MR copies/installs the source from there. I guess some files are not necessary at runtime, but considering these files in comparison to the base image I don't think it is an issue.